### PR TITLE
Add IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This repository is designed to simplify the installation process for the IDS/IPS
     ```sh
     /ip/firewall/raw/add action=drop chain=prerouting comment="IPS-drop_in_bad_traffic" src-address-list=Suricata
     /ip/firewall/raw/add action=drop chain=prerouting comment="IPS-drop_out_bad_traffic" dst-address-list=Suricata
+    /ipv6/firewall/raw/add action=drop chain=prerouting comment="IPS-drop_in_bad_traffic" src-address-list=Suricata
+    /ipv6/firewall/raw/add action=drop chain=prerouting comment="IPS-drop_out_bad_traffic" dst-address-list=Suricata
     ```
 3. Enable Mikrotik API:
     ```sh


### PR DESCRIPTION
Hi!

This is a small patch to handle alerts containing IPv6 addresses from eve.json.
After enabling via the ENABLE_IPV6 variable, instead of a librouteros.TrapError, events get properly processed, and added to the IPv6 address list. By default I set it turned off, since if dynamic prefixes are used, whitelisting requires additional logic and API requests. 
Also whitelisted LLA / "fe80:" addresses, since blocking that can probably cause problems. GUA-s and ULA-s (fc00:, fd00:) I think should be added to the whitelist by the user like LAN address in IPv4 via LOCAL_IP_PREFIX variable.

Tested it with: curl -6 testmyids.com and nmap -6, both events got added to the lists immediately.